### PR TITLE
Remove Table_LightEndTable as it doesn't exist anymore on VFE

### DIFF
--- a/Mods and Shit/VE Furniture/Patches/ve furniture patch.xml
+++ b/Mods and Shit/VE Furniture/Patches/ve furniture patch.xml
@@ -14,12 +14,6 @@
                     </value>
                 </Operation>
                 <Operation Class="PatchOperationReplace">
-                    <xpath>Defs/ThingDef[defName="Table_LightEndTable"]/designationCategory</xpath>
-                    <value>
-                        <designationCategory>Ferny_Bedroom</designationCategory>
-                    </value>
-                </Operation>
-                <Operation Class="PatchOperationReplace">
                     <xpath>Defs/ThingDef[defName="Table_RoyalEndTable"]/designationCategory</xpath>
                     <value>
                         <designationCategory>Ferny_Bedroom</designationCategory>


### PR DESCRIPTION
Quick patch removal. Seems like we have "desk lamps" on VFE now that we can put on top of other furniture, rendering the previous end table obsolete.